### PR TITLE
Сохраняем имя json-файла текущим днем, а не вчерашним.

### DIFF
--- a/fetch-data.js
+++ b/fetch-data.js
@@ -111,7 +111,7 @@ function getDataFromZoho(date, modeReport, resBody) {
 
 getDataFromZoho(new Date(), 'customReport', 'report')
   .then(function (data) {
-    fs.writeFileSync('./data/' + moment(new Date()).subtract(1, 'day').format('YYYY-MM-DD') + '.json', JSON.stringify(data, 0, 2));
+    fs.writeFileSync('./data/' + moment(new Date()).format('YYYY-MM-DD') + '.json', JSON.stringify(data, 0, 2));
     return fs.writeFileSync('./data/' + moment(new Date()).subtract(1, 'day').endOf('month').format('YYYY-MM') + '.json', JSON.stringify(data, 0, 2));
   })
   .catch(function (err) {


### PR DESCRIPTION
Со вчерашнего дня новый fetch-data скрипт был включен в работу на продакшене. Сегодня было обнаружено, что график беспорядочно уехал и ругался на отсутствие json-файла за 12-ое число.
Просто у нас front работает по схеме: в имена json-файла текущая дата, но данные в нём за вчерашний день.
Раньше sh-скрипт сохранял json с текущей датой в имени.
Пообщался с Мишей, он сказал front переделывать слишком долго выйдет. Поэтому решили оставить старую схему.
Убрал subtract 1 day.